### PR TITLE
Add Git Commands to README

### DIFF
--- a/.ebextensions/example.config
+++ b/.ebextensions/example.config
@@ -67,7 +67,7 @@ files:
       mount -t nfs4 -o nfsvers=4.1 $ENDPOINT /mnt/efs
 
       # Docker needs to be restarted to become aware of the new file system.
-      service docker restart
+      /usr/sbin/service docker restart
 commands:
   # Create a directory to which the EFS will be mouned,
   # only if it does not already exist.


### PR DESCRIPTION
- Add Git Add/Commit commands to README so `eb create` will pull the changed configuration
- Fix the `service` command, which caused _command not found_ errors

Fixes #1 
